### PR TITLE
docs: Add minimum VS code requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Highlight a JS Object, and get a TypeScript interface in your clipboard
 
 ## Requirements
 
-n/a
+- VS Code 1.44 or higher


### PR DESCRIPTION
Unable to install in VS code 1.42, added min requirement to the README